### PR TITLE
Update S81aria2

### DIFF
--- a/packages/aria2/S81aria2
+++ b/packages/aria2/S81aria2
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-[ -e /opt/var/aria2/session.dat ] || touch /opt/var/aria2/session.dat
+[ -e /Apps/opt/var/aria2/session.dat ] || touch /Apps/opt/var/aria2/session.dat
 
 ENABLED=yes
 PROCS=aria2c


### PR DESCRIPTION
Use /Apps/opt/var/aria2/session.dat instead of /opt/var/aria2/session.dat for lockfile
